### PR TITLE
updateTeacherDetailsPatch

### DIFF
--- a/src/Application/Teacher/Commands/UpdateTeacherDetails/UpdateTeacherDetailsCommand.cs
+++ b/src/Application/Teacher/Commands/UpdateTeacherDetails/UpdateTeacherDetailsCommand.cs
@@ -1,0 +1,12 @@
+﻿using Application.Common.Results;
+using Application.Teacher.Dtos;
+using MediatR;
+using Microsoft.AspNetCore.JsonPatch;
+
+namespace Application.Teacher.Commands.UpdateTeacherDetails
+{
+    public sealed record UpdateTeacherDetailsCommand(
+        Guid Id,
+        JsonPatchDocument<UpdateTeacherDetailsDto> PatchDoc) : IRequest<OperationResult>;
+
+}

--- a/src/Application/Teacher/Commands/UpdateTeacherDetails/UpdateTeacherDetailsCommandHandler.cs
+++ b/src/Application/Teacher/Commands/UpdateTeacherDetails/UpdateTeacherDetailsCommandHandler.cs
@@ -1,0 +1,71 @@
+﻿using Application.Common.Results;
+using Application.Student.Dtos;
+using Application.Teacher.Dtos;
+using Application.Teacher.Repository;
+using FluentValidation;
+using MediatR;
+
+namespace Application.Teacher.Commands.UpdateTeacherDetails
+{
+    public class UpdateTeacherDetailsCommandHandler : IRequestHandler<UpdateTeacherDetailsCommand, OperationResult>
+    {
+        private readonly ITeacherRepository _teacherRepository;
+        private readonly IValidator<UpdateTeacherDetailsDto> _dtoValidator;
+
+        // FIX 1: IAppDbContext är nu helt borttagen från konstruktorn
+        public UpdateTeacherDetailsCommandHandler(
+            ITeacherRepository teacherRepository, 
+            IValidator<UpdateTeacherDetailsDto> dtoValidator)
+        {
+            _teacherRepository = teacherRepository;
+            _dtoValidator = dtoValidator;
+        }
+        
+        public async Task<OperationResult> Handle(UpdateTeacherDetailsCommand request, CancellationToken ct)
+        {
+            var userEntity = await _teacherRepository.GetTrackedByIdAsync(request.Id, ct);
+            if (userEntity is null)
+            {
+                return OperationResult.Failure(Error.NotFound("Teacher.NotFound", $"Lärare med ID {request.Id} kunde inte hittas."));
+            }
+
+            var updateTeacherResponse = new UpdateTeacherDetailsDto()
+            {
+                FirstName = userEntity.FirstName,
+                LastName = userEntity.LastName,
+                Email = userEntity.Email,
+                SecurityNumber = userEntity.SecurityNumber
+            };
+
+            try
+            {
+                request.PatchDoc.ApplyTo(updateTeacherResponse);
+            }
+            catch (Exception ex)
+            {
+                return OperationResult.Failure(Error.Validation("Patch.InvalidOperation", ex.Message));
+            }
+
+            var validationResult = await _dtoValidator.ValidateAsync(updateTeacherResponse, ct);
+            if (!validationResult.IsValid)
+            {
+                return OperationResult.Failure(Error.Validation("Validation.Error", string.Join(", ", validationResult.Errors.Select(e => e.ErrorMessage))));
+            }
+
+            var newEmail = updateTeacherResponse.Email.Trim().ToLowerInvariant();
+            if (userEntity.Email != newEmail && await _teacherRepository.EmailExistsAsync(newEmail, ct))
+            {
+                return OperationResult.Failure(Error.Conflict("Teacher.EmailAlreadyExists", "Den nya e-postadressen används redan."));
+            }
+
+            userEntity.FirstName = updateTeacherResponse.FirstName;
+            userEntity.LastName = updateTeacherResponse.LastName;
+            userEntity.Email = newEmail;
+            userEntity.SecurityNumber = updateTeacherResponse.SecurityNumber;
+            userEntity.UpdatedAtUtc = DateTime.UtcNow;
+
+            // Använd repositoryt för att spara, enligt det nya mönstret
+            return await _teacherRepository.UpdateAsync(userEntity, ct);
+        }
+    }
+}

--- a/src/Application/Teacher/Commands/UpdateTeacherDetails/UpdateTeacherDetailsCommandValidator.cs
+++ b/src/Application/Teacher/Commands/UpdateTeacherDetails/UpdateTeacherDetailsCommandValidator.cs
@@ -1,0 +1,17 @@
+﻿using Application.Teacher.Dtos;
+using FluentValidation;
+
+namespace Application.Teacher.Commands.UpdateTeacherDetails
+{
+    public class UpdateTeacherDetailsCommandValidator : AbstractValidator<UpdateTeacherDetailsDto>
+    {
+        public UpdateTeacherDetailsCommandValidator()
+        {
+            RuleFor(t => t.FirstName).NotEmpty().MaximumLength(50);
+            RuleFor(t => t.LastName).NotEmpty().MaximumLength(50);
+            RuleFor(t => t.Email).NotEmpty().EmailAddress().MaximumLength(100);
+            RuleFor(t => t.SecurityNumber).NotEmpty().MaximumLength(20);
+            
+        }
+    }
+}

--- a/src/Application/Teacher/Dtos/UpdateTeacherDetailsDto.cs
+++ b/src/Application/Teacher/Dtos/UpdateTeacherDetailsDto.cs
@@ -1,0 +1,13 @@
+﻿namespace Application.Teacher.Dtos
+{
+    public class UpdateTeacherDetailsDto
+    {
+        public string FirstName { get; set; } = string.Empty;
+        public string LastName { get; set; } = string.Empty;
+        public string Email { get; set; } = string.Empty;
+        public string SecurityNumber { get; set; } = string.Empty;
+    }
+        
+        
+    
+}

--- a/src/StudyTeknik/Controllers/TeacherController.cs
+++ b/src/StudyTeknik/Controllers/TeacherController.cs
@@ -1,12 +1,14 @@
 ﻿using Application.Common.Results;
 using Application.Teacher.Commands.CreateTeacher;
 using Application.Teacher.Commands.UpdateTeacher;
+using Application.Teacher.Commands.UpdateTeacherDetails;
 using Application.Teacher.Dtos;
 using Application.Teacher.Queries.GetAllTeachers;
 using Application.Teacher.Queries.GetTeacherById;
 using Application.Teacher.Repository;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.JsonPatch;
 using Microsoft.AspNetCore.Mvc;
 
 namespace StudyTeknik.Controller
@@ -84,6 +86,25 @@ namespace StudyTeknik.Controller
                 };
             }
 
+            return NoContent();
+        }
+        [HttpPatch("UpdateTeacher/{id:guid}")]
+        public async Task<IActionResult> UpdateTeacherDetails(Guid id, [FromBody] 
+            JsonPatchDocument<UpdateTeacherDetailsDto> patchDoc, CancellationToken ct)
+        {
+            var command = new UpdateTeacherDetailsCommand(id, patchDoc);
+            
+            var result = await _mediator.Send(command, ct);
+
+            if (result.IsFailure)
+            {
+                return result.Error.Type switch
+                {
+                    ErrorType.NotFound => NotFound(result.Error),
+                    ErrorType.Conflict => Conflict(result.Error),
+                    _ => BadRequest(result.Error)
+                };
+            }
             return NoContent();
         }
     }


### PR DESCRIPTION
Jag har implementerat PATCH-funktionalitet för att kunna utföra specifika uppdateringar på en lärare, vilket innebär att jag bara behöver skicka den information som faktiskt ska ändras.

För att stödja detta har jag först installerat de nödvändiga NuGet-paketen (Microsoft.AspNetCore.JsonPatch och Microsoft.AspNetCore.Mvc.NewtonsoftJson) och konfigurerat mitt API-projekt i Program.cs.

Jag skapade ett UpdateTacherDetailsDto-objekt, som är en class (inte en record) eftersom vad jag har förståt att JsonPatch-biblioteket kräver det för att kunna applicera ändringar. 

I min UpdateTeacherDetailsCommandHandler implementerade jag en process i flera steg:

Hämta den befintliga UserEntity från databasen.

Applicera ändringarna från PatchDoc på DTO-kopian.

Validera det nya, ändrade DTO-objektet.

Föra över de godkända ändringarna tillbaka till den ursprungliga UserEntity.

