### PR TITLE
färdig med deleteTeacher

### DIFF
--- a/src/Application/Teacher/Commands/DeleteTeacher/DeleteTeacherCommand.cs
+++ b/src/Application/Teacher/Commands/DeleteTeacher/DeleteTeacherCommand.cs
@@ -1,0 +1,10 @@
+﻿using Application.Common.Results;
+using MediatR;
+
+namespace Application.Teacher.Commands.DeleteTeacher
+{
+    public sealed record DeleteTeacherCommand(Guid Id) : IRequest<OperationResult>;
+    
+        
+    
+}

--- a/src/Application/Teacher/Commands/DeleteTeacher/DeleteTeacherCommandValidator.cs
+++ b/src/Application/Teacher/Commands/DeleteTeacher/DeleteTeacherCommandValidator.cs
@@ -1,0 +1,12 @@
+﻿using FluentValidation;
+
+namespace Application.Teacher.Commands.DeleteTeacher
+{
+    public sealed class DeleteTeacherCommandValidator : AbstractValidator<DeleteTeacherCommand>
+    {
+        public DeleteTeacherCommandValidator()
+        {
+            RuleFor(t => t.Id).NotEmpty().WithMessage("Id cannot be empty.");
+        }
+    }
+}

--- a/src/Application/Teacher/Commands/DeleteTeacher/DeleterTeacherCommandHandler.cs
+++ b/src/Application/Teacher/Commands/DeleteTeacher/DeleterTeacherCommandHandler.cs
@@ -1,0 +1,47 @@
+﻿using Domain.Abstractions.Enum;
+using FluentValidation;
+
+namespace Application.Teacher.Commands.DeleteTeacher
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Application.Common.Results;
+    using Application.Teacher.Repository;
+    using Domain.Entities;
+    using MediatR;
+
+    public sealed class DeleterTeacherCommandHandler : IRequestHandler<DeleteTeacherCommand, OperationResult>
+    {
+        private readonly ITeacherRepository _teacherRepository;
+        private readonly IValidator<DeleteTeacherCommand> _validator;
+
+        public DeleterTeacherCommandHandler(ITeacherRepository teacherRepository, IValidator<DeleteTeacherCommand> validator)
+        {
+            _teacherRepository = teacherRepository;
+            _validator = validator;
+        }
+
+        public async Task<OperationResult> Handle(DeleteTeacherCommand request, CancellationToken ct)
+        {
+            var validationResult = await _validator.ValidateAsync(request, ct);
+            if (!validationResult.IsValid)
+            {
+                var error = Error.Validation("Validation.Error", "Lärar-ID får inte vara tomt.");
+                return OperationResult.Failure(error);
+            }
+
+            // Hämta läraren för att se om den existerar
+            var userEntity = await _teacherRepository.GetTrackedByIdAsync(request.Id, ct);
+
+            // Förenklad kontroll: Om vi inte får tillbaka något, finns inte läraren.
+            if (userEntity is null)
+            {
+                return OperationResult.Failure(Error.NotFound("Teacher.NotFound", $"Lärare med ID {request.Id} kunde inte hittas."));
+            }
+
+            // Anropa repositoryt för att utföra raderingen
+            return await _teacherRepository.DeleteAsync(userEntity.Id, ct); // Skicka med hela objektet
+        }
+    }
+}

--- a/src/Application/Teacher/Repository/ITeacherRepository.cs
+++ b/src/Application/Teacher/Repository/ITeacherRepository.cs
@@ -21,6 +21,8 @@ namespace Application.Teacher.Repository
          Task<OperationResult> UpdateAsync(UserEntity user, CancellationToken ct);
          Task<OperationResult>AddAsync(UserEntity user, CancellationToken ct);
          
+         Task<OperationResult> DeleteAsync(Guid id, CancellationToken ct);
+         
         
     }
 }

--- a/src/Infrastructure/Persistence/Repositories/TeacherRepository.cs
+++ b/src/Infrastructure/Persistence/Repositories/TeacherRepository.cs
@@ -120,5 +120,18 @@ namespace Infrastructure.Persistence.Repositories
             
             return await _db.Users.FirstOrDefaultAsync(u => u.Id == id && u.Role == UserRole.Teacher, ct);
         }
+        
+        public async Task<OperationResult> DeleteAsync(Guid id, CancellationToken ct)
+        {
+            var rowsAffected = await _db.Users
+                .Where (u => u.Id == id && u.Role == UserRole.Teacher)
+                .ExecuteDeleteAsync(ct);
+
+            if (rowsAffected == 0)
+            {
+                return OperationResult.Failure(Error.NotFound("Teacher.NotFound", $"Lärare med ID {id} kunde inte hittas."));
+            }
+            return OperationResult.Success();
+        }
     }
 }   

--- a/src/StudyTeknik/Controllers/TeacherController.cs
+++ b/src/StudyTeknik/Controllers/TeacherController.cs
@@ -1,5 +1,6 @@
 ﻿using Application.Common.Results;
 using Application.Teacher.Commands.CreateTeacher;
+using Application.Teacher.Commands.DeleteTeacher;
 using Application.Teacher.Commands.UpdateTeacher;
 using Application.Teacher.Commands.UpdateTeacherDetails;
 using Application.Teacher.Dtos;
@@ -105,6 +106,22 @@ namespace StudyTeknik.Controller
                     _ => BadRequest(result.Error)
                 };
             }
+            return NoContent();
+        }
+
+        [HttpDelete("DeleteTeacher/{id:guid}")]
+        public async Task<IActionResult> DeleteTeacher(Guid id, CancellationToken ct)
+        {
+            var command = new DeleteTeacherCommand(id);
+            var result = await _mediator.Send(command, ct);
+
+            if (result.IsFailure)
+            {
+                return result.Error.Type == ErrorType.NotFound
+                    ? NotFound(result.Error)
+                    : BadRequest(result.Error);
+            }
+
             return NoContent();
         }
     }


### PR DESCRIPTION
Byggt den sista delen av CRUD-funktionaliteten för lärare genom att implementera Delete.

Skapade en DeleteTeacherCommand som endast innehåller Id för läraren som ska raderas, samt en Validator som säkerställer att ett ID skickas med.

Jag utökade mitt ITeacherRepository med en DeleteAsync-metod och implementerade logiken i TeacherRepository för att effektivt ta bort läraren från databasen.

Jag byggde en DeleteTeacherCommandHandler vars enda ansvar är att ta emot kommandot, anropa repositoryts DeleteAsync-metod och returnera ett lyckat resultat.

Slutligen skapade jag en [HttpDelete("{id:guid}")]-endpoint i min TeachersController som tar emot anropet, skickar kommandot via MediatR och returnerar 204 No Content för att bekräfta att raderingen lyckades.